### PR TITLE
Add checkcookie redirect handling

### DIFF
--- a/wilhelmina/client.py
+++ b/wilhelmina/client.py
@@ -125,6 +125,70 @@ class WilmaClient:
             if not location:
                 raise AuthenticationError("No Location header in response")
 
+            # Handle checkcookie redirect - follow it to get the actual location
+            if "checkcookie" in location and "!" not in location:
+                logger.debug("Following checkcookie redirect: %s", location)
+                
+                # Use allow_redirects=False to see each redirect step
+                async with session.get(location, allow_redirects=False) as redirect_response:
+                    logger.debug("Checkcookie response status: %s", redirect_response.status)
+                    if redirect_response.status in [302, 303, 301, 307, 308]:
+                        new_location = redirect_response.headers.get("Location")
+                        if new_location:
+                            # If the new location still doesn't have !, try extracting from home page
+                            if "!" not in new_location and new_location.rstrip('/') == self.base_url:
+                                logger.debug("Redirect to root, extracting user ID from home page")
+                                async with session.get(self.base_url) as home_response:
+                                    if home_response.status != 200:
+                                        raise AuthenticationError(f"Failed to load home page: {home_response.status}")
+                                    
+                                    home_content = await home_response.text()
+                                    # Look for user ID in the page content - Wilma typically has it in URLs or JavaScript
+                                    import re
+                                    user_id_match = re.search(r'["\'/](![\w\d]+)["\'/]', home_content)
+                                    if user_id_match:
+                                        self.user_id = user_id_match.group(1)
+                                        logger.debug("Extracted user ID from home page: %s", self.user_id)
+                                        return
+                                    else:
+                                        # Try looking for it in a different pattern
+                                        user_id_match = re.search(r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)', home_content)
+                                        if user_id_match:
+                                            self.user_id = user_id_match.group(1)
+                                            logger.debug("Extracted user ID from home page (pattern 2): %s", self.user_id)
+                                            return
+                                        else:
+                                            raise AuthenticationError("Could not extract user ID from home page after checkcookie redirect")
+                            else:
+                                location = new_location
+                                logger.debug("Got redirect location: %s", location)
+                        else:
+                            raise AuthenticationError("No Location header in checkcookie redirect")
+                    else:
+                        # Some instances redirects to root, need to extract user ID differently
+                        logger.debug("No redirect from checkcookie, trying to find user ID from home page")
+                        async with session.get(self.base_url) as home_response:
+                            if home_response.status != 200:
+                                raise AuthenticationError(f"Failed to load home page: {home_response.status}")
+                            
+                            home_content = await home_response.text()
+                            # Look for user ID in the page content - Wilma typically has it in URLs or JavaScript
+                            import re
+                            user_id_match = re.search(r'["\'/](![\w\d]+)["\'/]', home_content)
+                            if user_id_match:
+                                self.user_id = user_id_match.group(1)
+                                logger.debug("Extracted user ID from home page: %s", self.user_id)
+                                return
+                            else:
+                                # Try looking for it in a different pattern
+                                user_id_match = re.search(r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)', home_content)
+                                if user_id_match:
+                                    self.user_id = user_id_match.group(1)
+                                    logger.debug("Extracted user ID from home page (pattern 2): %s", self.user_id)
+                                    return
+                                else:
+                                    raise AuthenticationError("Could not extract user ID from home page after checkcookie redirect")
+
             if "!" not in location:
                 raise AuthenticationError(f"Invalid Location header: {location}")
 

--- a/wilhelmina/client.py
+++ b/wilhelmina/client.py
@@ -128,7 +128,7 @@ class WilmaClient:
             # Handle checkcookie redirect - follow it to get the actual location
             if "checkcookie" in location and "!" not in location:
                 logger.debug("Following checkcookie redirect: %s", location)
-                
+
                 # Use allow_redirects=False to see each redirect step
                 async with session.get(location, allow_redirects=False) as redirect_response:
                     logger.debug("Checkcookie response status: %s", redirect_response.status)
@@ -136,29 +136,47 @@ class WilmaClient:
                         new_location = redirect_response.headers.get("Location")
                         if new_location:
                             # If the new location still doesn't have !, try extracting from home page
-                            if "!" not in new_location and new_location.rstrip('/') == self.base_url:
+                            if (
+                                "!" not in new_location
+                                and new_location.rstrip("/") == self.base_url
+                            ):
                                 logger.debug("Redirect to root, extracting user ID from home page")
                                 async with session.get(self.base_url) as home_response:
                                     if home_response.status != 200:
-                                        raise AuthenticationError(f"Failed to load home page: {home_response.status}")
-                                    
+                                        raise AuthenticationError(
+                                            f"Failed to load home page: {home_response.status}"
+                                        )
+
                                     home_content = await home_response.text()
                                     # Look for user ID in the page content - Wilma typically has it in URLs or JavaScript
                                     import re
-                                    user_id_match = re.search(r'["\'/](![\w\d]+)["\'/]', home_content)
+
+                                    user_id_match = re.search(
+                                        r'["\'/](![\w\d]+)["\'/]', home_content
+                                    )
                                     if user_id_match:
                                         self.user_id = user_id_match.group(1)
-                                        logger.debug("Extracted user ID from home page: %s", self.user_id)
+                                        logger.debug(
+                                            "Extracted user ID from home page: %s", self.user_id
+                                        )
                                         return
                                     else:
                                         # Try looking for it in a different pattern
-                                        user_id_match = re.search(r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)', home_content)
+                                        user_id_match = re.search(
+                                            r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)',
+                                            home_content,
+                                        )
                                         if user_id_match:
                                             self.user_id = user_id_match.group(1)
-                                            logger.debug("Extracted user ID from home page (pattern 2): %s", self.user_id)
+                                            logger.debug(
+                                                "Extracted user ID from home page (pattern 2): %s",
+                                                self.user_id,
+                                            )
                                             return
                                         else:
-                                            raise AuthenticationError("Could not extract user ID from home page after checkcookie redirect")
+                                            raise AuthenticationError(
+                                                "Could not extract user ID from home page after checkcookie redirect"
+                                            )
                             else:
                                 location = new_location
                                 logger.debug("Got redirect location: %s", location)
@@ -166,14 +184,19 @@ class WilmaClient:
                             raise AuthenticationError("No Location header in checkcookie redirect")
                     else:
                         # Some instances redirects to root, need to extract user ID differently
-                        logger.debug("No redirect from checkcookie, trying to find user ID from home page")
+                        logger.debug(
+                            "No redirect from checkcookie, trying to find user ID from home page"
+                        )
                         async with session.get(self.base_url) as home_response:
                             if home_response.status != 200:
-                                raise AuthenticationError(f"Failed to load home page: {home_response.status}")
-                            
+                                raise AuthenticationError(
+                                    f"Failed to load home page: {home_response.status}"
+                                )
+
                             home_content = await home_response.text()
                             # Look for user ID in the page content - Wilma typically has it in URLs or JavaScript
                             import re
+
                             user_id_match = re.search(r'["\'/](![\w\d]+)["\'/]', home_content)
                             if user_id_match:
                                 self.user_id = user_id_match.group(1)
@@ -181,13 +204,20 @@ class WilmaClient:
                                 return
                             else:
                                 # Try looking for it in a different pattern
-                                user_id_match = re.search(r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)', home_content)
+                                user_id_match = re.search(
+                                    r'user[Ii]d["\']?\s*[:=]\s*["\']?(![\w\d]+)', home_content
+                                )
                                 if user_id_match:
                                     self.user_id = user_id_match.group(1)
-                                    logger.debug("Extracted user ID from home page (pattern 2): %s", self.user_id)
+                                    logger.debug(
+                                        "Extracted user ID from home page (pattern 2): %s",
+                                        self.user_id,
+                                    )
                                     return
                                 else:
-                                    raise AuthenticationError("Could not extract user ID from home page after checkcookie redirect")
+                                    raise AuthenticationError(
+                                        "Could not extract user ID from home page after checkcookie redirect"
+                                    )
 
             if "!" not in location:
                 raise AuthenticationError(f"Invalid Location header: {location}")

--- a/wilhelmina/tests/test_client.py
+++ b/wilhelmina/tests/test_client.py
@@ -451,13 +451,13 @@ async def test_login_checkcookie_style_user_id_extraction_patterns(mock_session)
         home_context = AsyncMock()
         home_context.__aenter__.return_value = home_resp
 
-        def get_side_effect(url, **kwargs):
+        def get_side_effect(url, token_ctx=token_context, checkcookie_ctx=checkcookie_context, home_ctx=home_context, **kwargs):
             if "/token" in url:
-                return token_context
+                return token_ctx
             elif "checkcookie" in url:
-                return checkcookie_context
+                return checkcookie_ctx
             else:
-                return home_context
+                return home_ctx
 
         mock_session_instance.get.side_effect = get_side_effect
         mock_session_instance.post.return_value = login_context

--- a/wilhelmina/tests/test_client.py
+++ b/wilhelmina/tests/test_client.py
@@ -226,6 +226,314 @@ async def test_login_edge_cases(mock_logger) -> None:
 
 
 @pytest.mark.asyncio
+@patch("wilhelmina.client.aiohttp.ClientSession")
+async def test_login_checkcookie_style_checkcookie_redirect(mock_session) -> None:
+    """Test checkcookie style login with checkcookie redirect (no user ID in initial redirect)."""
+    client = WilmaClient("https://test.inschool.fi", debug=False)
+
+    # Login ID cookie
+    login_id_cookie = MagicMock()
+    login_id_cookie.value = "test_login_id"
+
+    # Set up token response mock
+    token_resp = AsyncMock()
+    token_resp.status = 200
+    token_resp.cookies = MagicMock()
+    token_resp.cookies.get = MagicMock(return_value=login_id_cookie)
+
+    # SID cookie
+    sid_cookie = MagicMock()
+    sid_cookie.value = "test_sid"
+
+    # Set up login response mock - checkcookie style (no user ID, just checkcookie)
+    login_resp = AsyncMock()
+    login_resp.status = 302
+    login_resp.cookies = MagicMock()
+    login_resp.cookies.get = MagicMock(return_value=sid_cookie)
+    login_resp.headers = {"Location": "https://test.inschool.fi/?checkcookie"}
+
+    # Set up checkcookie redirect response
+    checkcookie_resp = AsyncMock()
+    checkcookie_resp.status = 302
+    checkcookie_resp.headers = {"Location": "https://test.inschool.fi/"}
+
+    # Set up home page response with user ID in content
+    home_resp = AsyncMock()
+    home_resp.status = 200
+    home_resp.text = AsyncMock(return_value='''
+        <html>
+            <body>
+                <script>
+                    var userUrl = "/!9876543/index";
+                    window.location = userUrl;
+                </script>
+            </body>
+        </html>
+    ''')
+
+    # Configure session mock
+    mock_session_instance = mock_session.return_value
+    
+    # Set up context managers for different requests
+    token_context = AsyncMock()
+    token_context.__aenter__.return_value = token_resp
+    
+    login_context = AsyncMock()
+    login_context.__aenter__.return_value = login_resp
+    
+    checkcookie_context = AsyncMock()
+    checkcookie_context.__aenter__.return_value = checkcookie_resp
+    
+    home_context = AsyncMock()
+    home_context.__aenter__.return_value = home_resp
+
+    # Configure get and post methods to return appropriate context managers
+    def get_side_effect(url, **kwargs):
+        if "/token" in url:
+            return token_context
+        elif "checkcookie" in url:
+            return checkcookie_context
+        else:  # home page
+            return home_context
+
+    mock_session_instance.get.side_effect = get_side_effect
+    mock_session_instance.post.return_value = login_context
+
+    # Call login
+    await client.login("testuser", "testpass")
+
+    # Verify client state - should have extracted user ID from home page
+    assert client.user_id == "!9876543"
+    assert client._sid == "test_sid"
+
+    # Verify the sequence of requests
+    assert mock_session_instance.get.call_count == 3  # token, checkcookie, home page
+    assert mock_session_instance.post.call_count == 1  # login
+
+
+@pytest.mark.asyncio
+@patch("wilhelmina.client.aiohttp.ClientSession")
+async def test_login_checkcookie_style_no_redirect_from_checkcookie(mock_session) -> None:
+    """Test checkcookie style login when checkcookie doesn't redirect (status 200)."""
+    client = WilmaClient("https://test.inschool.fi", debug=False)
+
+    # Login ID cookie
+    login_id_cookie = MagicMock()
+    login_id_cookie.value = "test_login_id"
+
+    # Set up token response mock
+    token_resp = AsyncMock()
+    token_resp.status = 200
+    token_resp.cookies = MagicMock()
+    token_resp.cookies.get = MagicMock(return_value=login_id_cookie)
+
+    # SID cookie
+    sid_cookie = MagicMock()
+    sid_cookie.value = "test_sid"
+
+    # Set up login response mock - checkcookie style
+    login_resp = AsyncMock()
+    login_resp.status = 302
+    login_resp.cookies = MagicMock()
+    login_resp.cookies.get = MagicMock(return_value=sid_cookie)
+    login_resp.headers = {"Location": "https://test.inschool.fi/?checkcookie"}
+
+    # Set up checkcookie response that doesn't redirect (status 200)
+    checkcookie_resp = AsyncMock()
+    checkcookie_resp.status = 200
+
+    # Set up home page response with user ID
+    home_resp = AsyncMock()
+    home_resp.status = 200
+    home_resp.text = AsyncMock(return_value='''
+        <html>
+            <body>
+                <div id="user-info" data-user-id="!9876543">Welcome</div>
+            </body>
+        </html>
+    ''')
+
+    # Configure session mock
+    mock_session_instance = mock_session.return_value
+    
+    # Set up context managers
+    token_context = AsyncMock()
+    token_context.__aenter__.return_value = token_resp
+    
+    login_context = AsyncMock()
+    login_context.__aenter__.return_value = login_resp
+    
+    checkcookie_context = AsyncMock()
+    checkcookie_context.__aenter__.return_value = checkcookie_resp
+    
+    home_context = AsyncMock()
+    home_context.__aenter__.return_value = home_resp
+
+    def get_side_effect(url, **kwargs):
+        if "/token" in url:
+            return token_context
+        elif "checkcookie" in url and kwargs.get('allow_redirects') is False:
+            return checkcookie_context
+        else:  # home page (when checkcookie doesn't redirect)
+            return home_context
+
+    mock_session_instance.get.side_effect = get_side_effect
+    mock_session_instance.post.return_value = login_context
+
+    # Call login
+    await client.login("testuser", "testpass")
+
+    # Verify client state
+    assert client.user_id == "!9876543"
+    assert client._sid == "test_sid"
+
+
+@pytest.mark.asyncio
+@patch("wilhelmina.client.aiohttp.ClientSession")
+async def test_login_checkcookie_style_user_id_extraction_patterns(mock_session) -> None:
+    """Test different patterns for extracting user ID from checkcookie home page."""
+    client = WilmaClient("https://test.inschool.fi", debug=False)
+
+    # Setup basic mocks
+    login_id_cookie = MagicMock()
+    login_id_cookie.value = "test_login_id"
+    
+    token_resp = AsyncMock()
+    token_resp.status = 200
+    token_resp.cookies = MagicMock()
+    token_resp.cookies.get = MagicMock(return_value=login_id_cookie)
+
+    sid_cookie = MagicMock()
+    sid_cookie.value = "test_sid"
+
+    login_resp = AsyncMock()
+    login_resp.status = 302
+    login_resp.cookies = MagicMock()
+    login_resp.cookies.get = MagicMock(return_value=sid_cookie)
+    login_resp.headers = {"Location": "https://test.inschool.fi/?checkcookie"}
+
+    checkcookie_resp = AsyncMock()
+    checkcookie_resp.status = 302
+    checkcookie_resp.headers = {"Location": "https://test.inschool.fi/"}
+
+    mock_session_instance = mock_session.return_value
+
+    # Test pattern 1: URL in quotes
+    home_resp1 = AsyncMock()
+    home_resp1.status = 200
+    home_resp1.text = AsyncMock(return_value='<script>var url = "/!9876543/messages";</script>')
+
+    # Test pattern 2: userId variable
+    home_resp2 = AsyncMock()
+    home_resp2.status = 200
+    home_resp2.text = AsyncMock(return_value='<script>userId = "!9876544";</script>')
+
+    test_cases = [
+        (home_resp1, "!9876543"),
+        (home_resp2, "!9876544"),
+    ]
+
+    for home_resp, expected_user_id in test_cases:
+        # Reset client state
+        client.user_id = None
+        client._sid = None
+
+        # Set up context managers
+        token_context = AsyncMock()
+        token_context.__aenter__.return_value = token_resp
+        
+        login_context = AsyncMock()
+        login_context.__aenter__.return_value = login_resp
+        
+        checkcookie_context = AsyncMock()
+        checkcookie_context.__aenter__.return_value = checkcookie_resp
+        
+        home_context = AsyncMock()
+        home_context.__aenter__.return_value = home_resp
+
+        def get_side_effect(url, **kwargs):
+            if "/token" in url:
+                return token_context
+            elif "checkcookie" in url:
+                return checkcookie_context
+            else:
+                return home_context
+
+        mock_session_instance.get.side_effect = get_side_effect
+        mock_session_instance.post.return_value = login_context
+
+        # Call login
+        await client.login("testuser", "testpass")
+
+        # Verify the expected user ID was extracted
+        assert client.user_id == expected_user_id
+
+
+@pytest.mark.asyncio
+@patch("wilhelmina.client.aiohttp.ClientSession")
+async def test_login_checkcookie_style_extraction_failure(mock_session) -> None:
+    """Test checkcookie style login when user ID cannot be extracted from home page."""
+    client = WilmaClient("https://test.inschool.fi", debug=False)
+
+    # Setup mocks
+    login_id_cookie = MagicMock()
+    login_id_cookie.value = "test_login_id"
+    
+    token_resp = AsyncMock()
+    token_resp.status = 200
+    token_resp.cookies = MagicMock()
+    token_resp.cookies.get = MagicMock(return_value=login_id_cookie)
+
+    sid_cookie = MagicMock()
+    sid_cookie.value = "test_sid"
+
+    login_resp = AsyncMock()
+    login_resp.status = 302
+    login_resp.cookies = MagicMock()
+    login_resp.cookies.get = MagicMock(return_value=sid_cookie)
+    login_resp.headers = {"Location": "https://test.inschool.fi/?checkcookie"}
+
+    checkcookie_resp = AsyncMock()
+    checkcookie_resp.status = 302
+    checkcookie_resp.headers = {"Location": "https://test.inschool.fi/"}
+
+    # Home page without user ID pattern
+    home_resp = AsyncMock()
+    home_resp.status = 200
+    home_resp.text = AsyncMock(return_value='<html><body><h1>Welcome to Wilma</h1></body></html>')
+
+    mock_session_instance = mock_session.return_value
+    
+    # Set up context managers
+    token_context = AsyncMock()
+    token_context.__aenter__.return_value = token_resp
+    
+    login_context = AsyncMock()
+    login_context.__aenter__.return_value = login_resp
+    
+    checkcookie_context = AsyncMock()
+    checkcookie_context.__aenter__.return_value = checkcookie_resp
+    
+    home_context = AsyncMock()
+    home_context.__aenter__.return_value = home_resp
+
+    def get_side_effect(url, **kwargs):
+        if "/token" in url:
+            return token_context
+        elif "checkcookie" in url:
+            return checkcookie_context
+        else:
+            return home_context
+
+    mock_session_instance.get.side_effect = get_side_effect
+    mock_session_instance.post.return_value = login_context
+
+    # Should raise AuthenticationError when user ID cannot be extracted
+    with pytest.raises(AuthenticationError, match="Could not extract user ID from home page"):
+        await client.login("testuser", "testpass")
+
+
+@pytest.mark.asyncio
 async def test_login_response_errors() -> None:
     """Test various error conditions during login."""
     client = WilmaClient("https://test.inschool.fi")

--- a/wilhelmina/tests/test_client.py
+++ b/wilhelmina/tests/test_client.py
@@ -260,7 +260,8 @@ async def test_login_checkcookie_style_checkcookie_redirect(mock_session) -> Non
     # Set up home page response with user ID in content
     home_resp = AsyncMock()
     home_resp.status = 200
-    home_resp.text = AsyncMock(return_value='''
+    home_resp.text = AsyncMock(
+        return_value="""
         <html>
             <body>
                 <script>
@@ -269,21 +270,22 @@ async def test_login_checkcookie_style_checkcookie_redirect(mock_session) -> Non
                 </script>
             </body>
         </html>
-    ''')
+    """
+    )
 
     # Configure session mock
     mock_session_instance = mock_session.return_value
-    
+
     # Set up context managers for different requests
     token_context = AsyncMock()
     token_context.__aenter__.return_value = token_resp
-    
+
     login_context = AsyncMock()
     login_context.__aenter__.return_value = login_resp
-    
+
     checkcookie_context = AsyncMock()
     checkcookie_context.__aenter__.return_value = checkcookie_resp
-    
+
     home_context = AsyncMock()
     home_context.__aenter__.return_value = home_resp
 
@@ -345,34 +347,36 @@ async def test_login_checkcookie_style_no_redirect_from_checkcookie(mock_session
     # Set up home page response with user ID
     home_resp = AsyncMock()
     home_resp.status = 200
-    home_resp.text = AsyncMock(return_value='''
+    home_resp.text = AsyncMock(
+        return_value="""
         <html>
             <body>
                 <div id="user-info" data-user-id="!9876543">Welcome</div>
             </body>
         </html>
-    ''')
+    """
+    )
 
     # Configure session mock
     mock_session_instance = mock_session.return_value
-    
+
     # Set up context managers
     token_context = AsyncMock()
     token_context.__aenter__.return_value = token_resp
-    
+
     login_context = AsyncMock()
     login_context.__aenter__.return_value = login_resp
-    
+
     checkcookie_context = AsyncMock()
     checkcookie_context.__aenter__.return_value = checkcookie_resp
-    
+
     home_context = AsyncMock()
     home_context.__aenter__.return_value = home_resp
 
     def get_side_effect(url, **kwargs):
         if "/token" in url:
             return token_context
-        elif "checkcookie" in url and kwargs.get('allow_redirects') is False:
+        elif "checkcookie" in url and kwargs.get("allow_redirects") is False:
             return checkcookie_context
         else:  # home page (when checkcookie doesn't redirect)
             return home_context
@@ -397,7 +401,7 @@ async def test_login_checkcookie_style_user_id_extraction_patterns(mock_session)
     # Setup basic mocks
     login_id_cookie = MagicMock()
     login_id_cookie.value = "test_login_id"
-    
+
     token_resp = AsyncMock()
     token_resp.status = 200
     token_resp.cookies = MagicMock()
@@ -441,17 +445,23 @@ async def test_login_checkcookie_style_user_id_extraction_patterns(mock_session)
         # Set up context managers
         token_context = AsyncMock()
         token_context.__aenter__.return_value = token_resp
-        
+
         login_context = AsyncMock()
         login_context.__aenter__.return_value = login_resp
-        
+
         checkcookie_context = AsyncMock()
         checkcookie_context.__aenter__.return_value = checkcookie_resp
-        
+
         home_context = AsyncMock()
         home_context.__aenter__.return_value = home_resp
 
-        def get_side_effect(url, token_ctx=token_context, checkcookie_ctx=checkcookie_context, home_ctx=home_context, **kwargs):
+        def get_side_effect(
+            url,
+            token_ctx=token_context,
+            checkcookie_ctx=checkcookie_context,
+            home_ctx=home_context,
+            **kwargs,
+        ):
             if "/token" in url:
                 return token_ctx
             elif "checkcookie" in url:
@@ -478,7 +488,7 @@ async def test_login_checkcookie_style_extraction_failure(mock_session) -> None:
     # Setup mocks
     login_id_cookie = MagicMock()
     login_id_cookie.value = "test_login_id"
-    
+
     token_resp = AsyncMock()
     token_resp.status = 200
     token_resp.cookies = MagicMock()
@@ -500,20 +510,20 @@ async def test_login_checkcookie_style_extraction_failure(mock_session) -> None:
     # Home page without user ID pattern
     home_resp = AsyncMock()
     home_resp.status = 200
-    home_resp.text = AsyncMock(return_value='<html><body><h1>Welcome to Wilma</h1></body></html>')
+    home_resp.text = AsyncMock(return_value="<html><body><h1>Welcome to Wilma</h1></body></html>")
 
     mock_session_instance = mock_session.return_value
-    
+
     # Set up context managers
     token_context = AsyncMock()
     token_context.__aenter__.return_value = token_resp
-    
+
     login_context = AsyncMock()
     login_context.__aenter__.return_value = login_resp
-    
+
     checkcookie_context = AsyncMock()
     checkcookie_context.__aenter__.return_value = checkcookie_resp
-    
+
     home_context = AsyncMock()
     home_context.__aenter__.return_value = home_resp
 


### PR DESCRIPTION
### Checkcookie redirect handling

This fixes https://github.com/frwickst/wilma_ha/issues/1

1. Problem: After login, the Pirkkala instance redirects to `https://pirkkala.inschool.fi/?checkcookie` instead of directly providing a URL with the user ID format like `https://server/!userid`
2. Root Cause: The original code expected the Location header to contain an exclamation mark (!) with the user ID, but Pirkkala's checkcookie redirect goes to the root page without exposing the user ID in the URL
3. Solution: Modified `./pywilma/wilhelmina/client.py` to handle the checkcookie redirect by:
  - Following the redirect to see where it leads
  - When it redirects to the root page, fetching the home page content
  - Using regex patterns to extract the user ID from the page HTML content
  - Successfully extracting user ID from the home page

### Added Tests:

1. `test_login_checkcookie_style_checkcookie_redirect` - Tests the main scenario where:
  - Login redirects to `?checkcookie` (without user ID)
  - Checkcookie redirects to root page
  - User ID is extracted from home page content
2. `test_login_checkcookie_style_no_redirect_from_checkcookie` - Tests when checkcookie returns status 200 instead of redirecting
3. `test_login_checkcookie_style_user_id_extraction_patterns` - Tests different regex patterns for extracting user ID from HTML:
  - `var url = "/!1234567/messages"` (URL in quotes)
  - `userId = "!1234567"` (variable assignment)
4. `test_login_checkcookie_style_extraction_failure` - Tests error handling when user ID cannot be found in home page

### Result:

* Login to Pirkkala Wilma works:

```
❯ poetry run wilhelmina login
Login successful!
```

* Messages can be listed:

```
❯ poetry run wilhelmina messages
                                 Messages
┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃      ID ┃ Subject                    ┃ Date             ┃ Sender               ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
... real messages follow
```

* Messages can be read:

```
❯ poetry run wilhelmina message 1520946
Message subject here
From: Sender Name (S.N)
Date: 2025-08-07 12:23

Message text here.
```

* All tests pass:

```
collected 40 items

 wilhelmina/tests/test_client.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓    52% █████▍
 wilhelmina/tests/test_error_handling.py ✓✓✓✓             62% ██████▍
 wilhelmina/tests/test_init.py ✓✓✓✓✓                      75% ███████▌
 wilhelmina/tests/test_models.py ✓✓✓✓✓                    88% ████████▊
 wilhelmina/tests/test_unread_messages.py ✓✓✓✓            98% █████████▊
 wilhelmina/tests/test_utils.py ✓                        100% ██████████

Results (0.56s):
      40 passed
```
